### PR TITLE
fix: handle CFBoolean tabId in ToolRouter (silent-nil bug)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules/
 # Runtime / build artifacts
 *.sock
 *.profraw
+*.log
 .worktrees/
 .superpowers/
 

--- a/ClaudeInSafari Extension/Info.plist
+++ b/ClaudeInSafari Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.6</string>
+	<string>1.2.7</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ClaudeInSafari Extension/Resources/manifest.json
+++ b/ClaudeInSafari Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Claude in Safari",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "description": "Claude browser automation for Safari — control Safari from Claude Code CLI.",
 
     "permissions": [

--- a/ClaudeInSafari/Info.plist
+++ b/ClaudeInSafari/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.6</string>
+	<string>1.2.7</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/ClaudeInSafari/MCP/ToolRouter.swift
+++ b/ClaudeInSafari/MCP/ToolRouter.swift
@@ -465,7 +465,7 @@ class ToolRouter: MCPSocketServerDelegate {
     // MARK: - Native Screenshot / Zoom
 
     private func handleScreenshotAction(action: String, arguments: [String: Any], id: Any?, clientId: String) {
-        let tabIdOpt = arguments["tabId"] as? Int
+        let tabIdOpt = parseTabId(arguments)
         let tabId = tabIdOpt ?? -1
         if action == "screenshot" {
             screenshotService.captureScreenshot(tabId: tabIdOpt) { [weak self] result in
@@ -533,7 +533,7 @@ class ToolRouter: MCPSocketServerDelegate {
             sendError(id: id, code: -32000, message: "action parameter is required", to: clientId)
             return
         }
-        let tabId = (arguments["tabId"] as? Int) ?? -1
+        let tabId = parseTabId(arguments) ?? -1
 
         switch action {
         case "start_recording":
@@ -699,6 +699,16 @@ class ToolRouter: MCPSocketServerDelegate {
             }
             if converted.count == 4 { return (converted[0], converted[1], converted[2], converted[3]) }
         }
+        return nil
+    }
+
+    /// Parse `tabId` from tool arguments, tolerating Int, Double, or NSNumber
+    /// (including NSNumber(bool:) which fails `as? Int`). Internal for unit tests.
+    func parseTabId(_ arguments: [String: Any]) -> Int? {
+        guard let raw = arguments["tabId"] else { return nil }
+        if let i = raw as? Int { return i }
+        if let d = raw as? Double { return Int(d) }
+        if let n = raw as? NSNumber { return n.intValue }
         return nil
     }
 
@@ -1060,7 +1070,7 @@ class ToolRouter: MCPSocketServerDelegate {
             }
             sendResult(id: id, result: ["content": contentDicts], to: clientId)
             // Post-action hook: fire-and-forget GIF frame capture on success only
-            let tabId = (arguments["tabId"] as? Int) ?? -1
+            let tabId = parseTabId(arguments) ?? -1
             let action = (arguments["action"] as? String) ?? toolName
             let coordinate = parseCoordinate(arguments["coordinate"])
             maybeAddGifFrame(tabId: tabId, action: action, coordinate: coordinate)

--- a/Tests/Swift/ToolRouterTests.swift
+++ b/Tests/Swift/ToolRouterTests.swift
@@ -827,6 +827,34 @@ final class ToolRouterDispatchTests: XCTestCase {
         XCTAssertNil(router.parseZoomRegion([:]))
     }
 
+    // MARK: - parseTabId
+
+    func testParseTabId_int_returnsValue() {
+        XCTAssertEqual(router.parseTabId(["tabId": 42]), 42)
+    }
+
+    func testParseTabId_double_truncatesToInt() {
+        XCTAssertEqual(router.parseTabId(["tabId": 7.9]), 7)
+    }
+
+    func testParseTabId_missing_returnsNil() {
+        XCTAssertNil(router.parseTabId([:]))
+    }
+
+    // JSONSerialization on the native bridge can deliver integer 1 as __NSCFBoolean
+    // (kCFBooleanTrue), which fails `as? Int` and previously caused tabId to fall
+    // through to -1, silently targeting the wrong tab. parseTabId must handle this.
+    func testParseTabId_cfBoolean_returnsIntValue() {
+        let arguments: [String: Any] = ["tabId": kCFBooleanTrue as Any]
+        XCTAssertEqual(router.parseTabId(arguments), 1,
+                       "parseTabId must resolve kCFBooleanTrue to Int 1, not nil")
+    }
+
+    func testParseTabId_nsNumber_returnsIntValue() {
+        let arguments: [String: Any] = ["tabId": NSNumber(value: 5)]
+        XCTAssertEqual(router.parseTabId(arguments), 5)
+    }
+
     // MARK: - Startup Cleanup (Spec 023 H1 + M1)
 
     func testPerformStartupCleanup_truncatesQueue() throws {

--- a/Tests/Swift/ToolRouterTests.swift
+++ b/Tests/Swift/ToolRouterTests.swift
@@ -855,6 +855,15 @@ final class ToolRouterDispatchTests: XCTestCase {
         XCTAssertEqual(router.parseTabId(arguments), 5)
     }
 
+    // kCFBooleanFalse bridges through the NSNumber branch with intValue == 0.
+    // Documenting this explicitly: `tabId: false` resolves to 0 (not nil, not -1).
+    // Both 0 and -1 are invalid Safari tab IDs (Safari tabs start at 1), but they
+    // are different dictionary keys for GIF recording — keep the behaviour pinned.
+    func testParseTabId_cfBooleanFalse_returnsZero() {
+        let arguments: [String: Any] = ["tabId": kCFBooleanFalse as Any]
+        XCTAssertEqual(router.parseTabId(arguments), 0)
+    }
+
     // MARK: - Startup Cleanup (Spec 023 H1 + M1)
 
     func testPerformStartupCleanup_truncatesQueue() throws {


### PR DESCRIPTION
## Summary
- `JSONSerialization` on the native bridge can deliver integer `1` as `__NSCFBoolean`, which fails `as? Int` — causing `tabId` to fall through to `-1` and silently target the wrong tab (screenshots, `gif_creator`, post-action GIF frame hook).
- Added `parseTabId(_:)` helper in `ToolRouter.swift` handling `Int` / `Double` / `NSNumber` / `CFBoolean`. Replaced 3 call sites (lines 468, 536, 1073). Mirrors existing `parseZoomRegion` / `parseCoordinate` pattern called out in `CLAUDE.md`.
- Added XCTest cases in `ToolRouterTests.swift` covering Int, Double, missing, and `kCFBooleanTrue` (the actual JSONSerialization-produced offender).
- Bumped version to 1.2.7 across both `Info.plist`s + `manifest.json`. Added `*.log` to `.gitignore`.

Surfaced by review on #64 (out of scope there — that PR is the tabs-manager lock fix).

## Test plan
- [x] `xcodebuild test` — `ToolRouterDispatchTests` 34/34 pass (includes new `parseTabId` cases)
- [ ] `make test-all` (JS + Swift) green in CI
- [ ] CI version-sync check passes
- [ ] Manual: invoke `screenshot` / `gif_creator` with `tabId: 1` from a client that bridges as `__NSCFBoolean`; verify it targets tab 1 (not -1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)