### PR TITLE
fix: log warning on chat button sendMessage failure

### DIFF
--- a/ClaudeInSafari Extension/Info.plist
+++ b/ClaudeInSafari Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.7</string>
+	<string>1.2.8</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ClaudeInSafari Extension/Resources/content-scripts/agent-visual-indicator.js
+++ b/ClaudeInSafari Extension/Resources/content-scripts/agent-visual-indicator.js
@@ -230,7 +230,9 @@
 
   dismissBtn.addEventListener('click', function () {
     hideStaticIndicator();
-    browser.runtime.sendMessage({ type: 'DISMISS_STATIC_INDICATOR_FOR_GROUP' }).catch(function () {});
+    browser.runtime.sendMessage({ type: 'DISMISS_STATIC_INDICATOR_FOR_GROUP' }).catch(function () {
+      // Background page suspended — indicator already hidden locally above
+    });
   });
 
   // ── Message listener ──────────────────────────────────────────────────────

--- a/ClaudeInSafari Extension/Resources/content-scripts/agent-visual-indicator.js
+++ b/ClaudeInSafari Extension/Resources/content-scripts/agent-visual-indicator.js
@@ -223,7 +223,9 @@
 
   chatBtn.addEventListener('click', function () {
     // browser.tabs is unavailable in content scripts — route through background.
-    browser.runtime.sendMessage({ type: 'OPEN_CLAUDE_TAB' }).catch(function () {});
+    browser.runtime.sendMessage({ type: 'OPEN_CLAUDE_TAB' }).catch(function (err) {
+      console.warn('agent-indicator: failed to open Claude tab via background:', err);
+    });
   });
 
   dismissBtn.addEventListener('click', function () {

--- a/ClaudeInSafari Extension/Resources/manifest.json
+++ b/ClaudeInSafari Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Claude in Safari",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "description": "Claude browser automation for Safari — control Safari from Claude Code CLI.",
 
     "permissions": [

--- a/ClaudeInSafari/Info.plist
+++ b/ClaudeInSafari/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.7</string>
+	<string>1.2.8</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/Tests/JS/agent-visual-indicator.test.js
+++ b/Tests/JS/agent-visual-indicator.test.js
@@ -174,6 +174,23 @@ describe('agent-visual-indicator content script', function () {
     await Promise.resolve(); // drain rejection microtask (prevent unhandled rejection warning)
   });
 
+  // T16 - chat button rejection: console.warn emitted with error context (no local fallback)
+  test('T16: chat button click warns to console when sendMessage rejects', async function () {
+    var warnSpy = jest.spyOn(console, 'warn').mockImplementation(function () {});
+    var err = new Error('Extension context invalid');
+    var result = loadIndicator({
+      sendMessageImpl: function () { return Promise.reject(err); },
+    });
+    var chatButton = result.host.shadowRoot.querySelector('#claude-static-chat-button');
+    chatButton.click();
+    await Promise.resolve(); // drain rejection microtask
+    expect(warnSpy).toHaveBeenCalledWith(
+      'agent-indicator: failed to open Claude tab via background:',
+      err
+    );
+    warnSpy.mockRestore();
+  });
+
   // T13 - heartbeat: success=false hides static indicator
   test('T13: heartbeat response success=false hides static indicator', async function () {
     jest.useFakeTimers();


### PR DESCRIPTION
## Summary

Chat button click in `agent-visual-indicator.js` silently swallowed errors from `browser.runtime.sendMessage({ type: 'OPEN_CLAUDE_TAB' })`. If the background page was suspended, click did nothing — no tab opened, no error, no log.

Stop and dismiss buttons hide their UI locally before sending, so their swallowed catches are documented best-effort. Chat button has no local fallback (content scripts can't open tabs), so a silent catch made debugging suspended-background-page failures impossible.

Minimum fix: log a `console.warn` with error context in the catch handler. Surfaced by silent-failure review on PR #64.

## Changes

- `ClaudeInSafari Extension/Resources/content-scripts/agent-visual-indicator.js`: chat button catch now logs `agent-indicator: failed to open Claude tab via background:` with the rejection reason.

## Test plan

- [ ] `npm test` passes
- [ ] `node --check` on modified file passes (verified)
- [ ] Manual: trigger chat button while background suspended, observe warning in content-script console
