### PR TITLE
fix(onboarding): drop confusing Safari.app fallback

### DIFF
--- a/ClaudeInSafari Extension/Info.plist
+++ b/ClaudeInSafari Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.11</string>
+	<string>1.2.12</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ClaudeInSafari Extension/Resources/manifest.json
+++ b/ClaudeInSafari Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Claude in Safari",
-    "version": "1.2.11",
+    "version": "1.2.12",
     "description": "Claude browser automation for Safari — control Safari from Claude Code CLI.",
 
     "permissions": [

--- a/ClaudeInSafari/App/OnboardingWindowController.swift
+++ b/ClaudeInSafari/App/OnboardingWindowController.swift
@@ -281,23 +281,14 @@ final class OnboardingWindowController: NSWindowController {
     }
 
     @objc private func openSafariSettings() {
-        // Try SFSafariApplication.showPreferencesForExtension first — opens Safari Settings
-        // directly to the Extensions pane. Falls back to opening Safari.app if it fails.
-        //
-        // History: this API was broken in early macOS 26 betas (SFErrorDomain error 4), so an
-        // AppleScript/osascript workaround was used instead. That workaround was removed because
-        // it requires Automation permission for System Events, which triggers a TCC dialog on
-        // every launch under App Sandbox. showPreferencesForExtension works on macOS 26.3+;
-        // on older versions that still have the bug, the fallback opens Safari.app directly.
+        // showPreferencesForExtension opens Safari Settings directly to the Extensions pane.
+        // If it fails (unsigned dev build, or macOS bug), we do NOT fall back to opening
+        // Safari.app generically — that lands on Safari's start page (e.g. SpeedReader),
+        // which is confusing. The onboarding UI already shows manual steps.
         let extensionBundleID = "com.chriscantu.claudeinsafari.extension"
         SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleID) { error in
             if let error = error {
-                NSLog("OnboardingWindowController: showPreferencesForExtension failed: %@ — falling back to Safari.app", error.localizedDescription)
-                DispatchQueue.main.async {
-                    if !NSWorkspace.shared.open(URL(fileURLWithPath: "/Applications/Safari.app")) {
-                        NSLog("OnboardingWindowController: Safari.app fallback also failed")
-                    }
-                }
+                NSLog("OnboardingWindowController: showPreferencesForExtension failed: %@ — user should follow the manual steps shown in onboarding", error.localizedDescription)
             }
         }
     }

--- a/ClaudeInSafari/Info.plist
+++ b/ClaudeInSafari/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.11</string>
+	<string>1.2.12</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

- Drops the `NSWorkspace.shared.open(/Applications/Safari.app)` fallback in `OnboardingWindowController.openSafariSettings()`.
- When `SFSafariApplication.showPreferencesForExtension` errors, opening Safari.app generically lands on the start page (e.g. SpeedReader), which is confusing — the user clicked "Open Safari Settings" expecting the Extensions pane.
- The onboarding UI already shows manual steps for users on macOS versions where `showPreferencesForExtension` is broken (early macOS 26 betas had `SFErrorDomain` 4). The `NSLog` line still records the failure for diagnostics.

## Behavior

| Path | Before | After |
|---|---|---|
| API succeeds (macOS 26.3+) | Opens Extensions pane | Opens Extensions pane |
| API errors | Opens Safari.app start page | No-op; user follows on-screen manual steps |

## Test plan

- [x] `make test-swift` — full suite passes
- [ ] Manual smoke: launch onboarding window, click "Open Safari Settings" — confirm Extensions pane opens (happy path) on macOS 26.3+
- [ ] Cannot test broken-API path on host (requires older macOS); fallback removal is by inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
